### PR TITLE
Fix imports for reorganized package

### DIFF
--- a/data_download.ipynb
+++ b/data_download.ipynb
@@ -12,7 +12,7 @@
    },
    "source": [
     "# Start by downloading the data. This will arrive raw, unfiltered. We'll handle that in the next step. This download will take 310.26 GB of space.\n",
-    "from download.bulk_dl import download_data\n",
+    "from ris_icequakes.download.bulk_dl import download_data\n",
     "download_data()"
    ],
    "outputs": [
@@ -2290,7 +2290,7 @@
    "cell_type": "code",
    "source": [
     "# This failed to download the StationXML file for XH.DR08.xml, so we'll manually get that one\n",
-    "from download.sta_inv import get_sta_inv_online\n",
+    "from ris_icequakes.download.sta_inv import get_sta_inv_online\n",
     "\n",
     "station = 'DR05'\n",
     "\n",
@@ -2316,7 +2316,7 @@
     "# import os\n",
     "# import glob\n",
     "# import obspy as op\n",
-    "# from download.sta_inv import get_sta_inv_online\n",
+    "# from ris_icequakes.download.sta_inv import get_sta_inv_online\n",
     "# from concurrent.futures import ThreadPoolExecutor, as_completed\n",
     "#\n",
     "# output_path = 'outputs/prepared_data_cache/'\n",
@@ -2387,7 +2387,7 @@
    "cell_type": "code",
    "source": [
     "import obspy as op\n",
-    "from download.otf import process_otf\n",
+    "from ris_icequakes.download.otf import process_otf\n",
     "st = op.read('outputs/raw_data_cache/20141128/XH_DR14/HHZ.mseed')\n",
     "st = st.trim(starttime=op.UTCDateTime(2014, 11, 28, 12, 0, 0),\n",
     "             endtime=op.UTCDateTime(2014, 11, 28, 12, 0, 30))\n",

--- a/detect.ipynb
+++ b/detect.ipynb
@@ -11,8 +11,8 @@
     }
    },
    "source": [
-    "from detection.iterator import iterate_all, get_all_traces\n",
-    "from download.otf import process_otf\n",
+    "from ris_icequakes.detection.iterator import iterate_all, get_all_traces\n",
+    "from ris_icequakes.download.otf import process_otf\n",
     "import obspy as op\n",
     "from obspy.signal.trigger import plot_trigger, recursive_sta_lta, trigger_onset\n",
     "import os\n",
@@ -56,8 +56,8 @@
    "cell_type": "code",
    "source": [
     "import multiprocessing as mp\n",
-    "from detection.stalta import detect_stalta_fromtracepath\n",
-    "from detection.iterator import get_all_traces, get_incomplete_traces\n",
+    "from ris_icequakes.detection.stalta import detect_stalta_fromtracepath\n",
+    "from ris_icequakes.detection.iterator import get_all_traces, get_incomplete_traces\n",
     "\n",
     "trace_list = get_incomplete_traces()\n",
     "mp.freeze_support()\n",


### PR DESCRIPTION
## Summary
- fix notebook import paths to use new `ris_icequakes.*` modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc3283dd083299284def33a1706c8